### PR TITLE
UI work for samples/preview instead of config option list

### DIFF
--- a/Configuration/BaseSubstitution.cs
+++ b/Configuration/BaseSubstitution.cs
@@ -4,6 +4,8 @@ namespace Sequencer.Configuration
 {
     public abstract class BaseSubstitution
     {
+        protected BaseSubstitution() { Replace = ""; With = ""; CaseSensitive = false; }
+
         [XmlAttribute("replace")]
         public string Replace { get; set; }
         [XmlAttribute("with")]

--- a/Configuration/CharacterSequenceItem.cs
+++ b/Configuration/CharacterSequenceItem.cs
@@ -12,9 +12,31 @@ namespace Sequencer.Configuration
             Length = 1;
             LengthStrength = StrengthEnum.Full;
             AllowDuplicate = true;
+            Characters = new OverridingCharacterList();
         }
 
         public OverridingCharacterList Characters { get; set; }
+
+        public override double entropy(PasswordSequenceConfiguration config)
+        {
+            double entropyVal = 0;
+
+            if (Length > 0)
+            {
+                if (Characters.Count > 0)
+                {
+                    entropyVal += Math.Log(Characters.Count, 2);
+                }
+                if (config.DefaultCharacters.Count > 0 && !Characters.Override)
+                {
+                    entropyVal += Math.Log(config.DefaultCharacters.Count, 2);
+                }
+                entropyVal *= Length;
+            }
+            /* TODO: other properties */
+
+            return entropyVal;
+        }
 
         [XmlAttribute("allowDuplicate")]
         public bool AllowDuplicate { get; set; }

--- a/Configuration/CharacterSequenceItem.cs
+++ b/Configuration/CharacterSequenceItem.cs
@@ -42,10 +42,23 @@ namespace Sequencer.Configuration
         public bool AllowDuplicate { get; set; }
 
         [XmlAttribute("length")]
-        public byte Length { get; set; }
+        public uint Length { get; set; }
 
         [XmlIgnore]
-        public StrengthEnum LengthStrength { get; set; }
+        private StrengthEnum _myLenStren;
+        public StrengthEnum LengthStrength
+        {
+            get { return _myLenStren; }
+            set
+            {
+                if (value > StrengthEnum.Full)
+                    _myLenStren = StrengthEnum.Full;
+                else if (value < 0)
+                    _myLenStren = 0;
+                else
+                    _myLenStren = value;
+            }
+        }
 
         [XmlAttribute("lengthStrength")]
         [EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
@@ -54,6 +67,5 @@ namespace Sequencer.Configuration
             get { return LengthStrength.ToString().ToLower(); }
             set { LengthStrength = (StrengthEnum)Enum.Parse(typeof(StrengthEnum), value, true); }
         }
-
     }
 }

--- a/Configuration/SequenceItem.cs
+++ b/Configuration/SequenceItem.cs
@@ -14,7 +14,19 @@ namespace Sequencer.Configuration
         }
 
         [XmlIgnore]
-        public PercentEnum Probability { get; set; }
+        private PercentEnum _myProb;
+        public PercentEnum Probability {
+            get { return _myProb; }
+            set
+            {
+                if (value > PercentEnum.Always)
+                    _myProb = PercentEnum.Always;
+                else if (value < PercentEnum.Never)
+                    _myProb = PercentEnum.Never;
+                else
+                    _myProb = value;
+            }
+        }
 
         public abstract double entropy(PasswordSequenceConfiguration config);
 

--- a/Configuration/SequenceItem.cs
+++ b/Configuration/SequenceItem.cs
@@ -16,6 +16,8 @@ namespace Sequencer.Configuration
         [XmlIgnore]
         public PercentEnum Probability { get; set; }
 
+        public abstract double entropy(PasswordSequenceConfiguration config);
+
         [XmlAttribute("probability")]
         [EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
         public string XmlProbability

--- a/Configuration/WordSequenceItem.cs
+++ b/Configuration/WordSequenceItem.cs
@@ -37,7 +37,23 @@ namespace Sequencer.Configuration
         public SubstitutionList Substitutions { get; set; }
 
         [XmlIgnore]
-        public CapitalizeEnum Capitalize { get; set; }
+        private CapitalizeEnum _myCapChance;
+        public CapitalizeEnum Capitalize
+        {
+            get
+            {
+                return _myCapChance;
+            }
+            set
+            {
+                if (value > CapitalizeEnum.Always && value != CapitalizeEnum.Proper)
+                    _myCapChance = CapitalizeEnum.Always;
+                else if (value < CapitalizeEnum.Never)
+                    _myCapChance = CapitalizeEnum.Never;
+                else
+                    _myCapChance = value;
+            }
+        }
 
         [XmlAttribute("capitalize")]
         [EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
@@ -48,7 +64,19 @@ namespace Sequencer.Configuration
         }
 
         [XmlIgnore]
-        public PercentEnum Substitution { get; set; }
+        private PercentEnum _mySubstPercent;
+        public PercentEnum Substitution {
+            get { return _mySubstPercent; }
+            set
+            {
+                if (value > PercentEnum.Always)
+                    _mySubstPercent = PercentEnum.Always;
+                else if (value < PercentEnum.Never)
+                    _mySubstPercent = PercentEnum.Never;
+                else
+                    _mySubstPercent = value;
+            }
+        }
 
         [XmlAttribute("substitution")]
         [EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]

--- a/Configuration/WordSequenceItem.cs
+++ b/Configuration/WordSequenceItem.cs
@@ -38,6 +38,7 @@ namespace Sequencer.Configuration
 
         [XmlIgnore]
         private CapitalizeEnum _myCapChance;
+        [XmlIgnore]
         public CapitalizeEnum Capitalize
         {
             get
@@ -65,6 +66,7 @@ namespace Sequencer.Configuration
 
         [XmlIgnore]
         private PercentEnum _mySubstPercent;
+        [XmlIgnore]
         public PercentEnum Substitution {
             get { return _mySubstPercent; }
             set

--- a/Configuration/WordSequenceItem.cs
+++ b/Configuration/WordSequenceItem.cs
@@ -10,6 +10,24 @@ namespace Sequencer.Configuration
         {
             Capitalize = CapitalizeEnum.Proper;
             Substitution = PercentEnum.Always;
+            Words = new OverridingWordList();
+        }
+
+        public override double entropy(PasswordSequenceConfiguration config)
+        {
+            double entropyVal = 0;
+
+            if (Words.Count > 0)
+            {
+                entropyVal += Math.Log(Words.Count, 2);
+            }
+            if (config.DefaultWords.Count > 0 && !Words.Override)
+            {
+                entropyVal += Math.Log(config.DefaultWords.Count, 2);
+            }
+            /* TODO: other properties */
+
+            return entropyVal;
         }
 
         public OverridingWordList Words { get; set; }
@@ -39,6 +57,5 @@ namespace Sequencer.Configuration
             get { return Substitution.ToString().ToLower(); }
             set { Substitution = (PercentEnum)Enum.Parse(typeof(PercentEnum), value, true); }
         }
-
     }
 }

--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -56,7 +56,16 @@ namespace Sequencer.Forms
         public delegate void LoadConfigDelegate(bool loadTextFields);
         private void RefreshOnTimer(Object o, System.Timers.ElapsedEventArgs e)
         {
-            this.Invoke(new LoadConfigDelegate(LoadConfigurationDetails), new object[] { false });
+            try
+            {
+                this.Invoke(new LoadConfigDelegate(LoadConfigurationDetails), new object[] { false });
+            }
+            catch (InvalidOperationException)
+            {
+                /* this is usually because we closed the form before the timer
+                 * expired; if that's the case there is no reason to refresh.
+                 */
+            }
         }
 
         public MainForm()

--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -45,7 +45,6 @@ namespace Sequencer.Forms
         private ToolStripButton toolStripButton2;
         private ToolStripButton tsbDeleteSubstitution;
         private ColumnHeader columnHeader1;
-        private ColumnHeader columnHeader2;
         private ColumnHeader columnHeader3;
         private SubstitutionListControl substitutionList1;
 
@@ -105,13 +104,12 @@ namespace Sequencer.Forms
             {
                 ListViewItem listItem = new ListViewItem();
 
-                listItem.SubItems.Add(sequenceItem.Probability.ToString());
                 listItem.Tag = sequenceItem;
 
                 if (sequenceItem is CharacterSequenceItem)
                 {
                     CharacterSequenceItem characterSequenceItem = (CharacterSequenceItem)sequenceItem;
-                    listItem.Text = "Characters";
+                    listItem.Text = "Characters (" + sequenceItem.Probability.ToString() + ")";
                     listItem.SubItems.Add(string.Format("Length: {0} ({1}), Override: {2}",
                         characterSequenceItem.Length,
                         characterSequenceItem.LengthStrength.ToString(),
@@ -121,8 +119,19 @@ namespace Sequencer.Forms
                 else if (sequenceItem is WordSequenceItem)
                 {
                     WordSequenceItem wordSequenceItem = (WordSequenceItem)sequenceItem;
+                    string itemText = "Word";
 
-                    listItem.Text = "Word";
+                    if (sequenceItem.Probability == Sequencer.Configuration.PercentEnum.Never)
+                    {
+                        listItem.Font = new Font(listItem.Font, listItem.Font.Style | FontStyle.Strikeout);
+                    }
+                    else if (sequenceItem.Probability < Sequencer.Configuration.PercentEnum.Always)
+                    {
+                        listItem.Font = new Font(listItem.Font, listItem.Font.Style | FontStyle.Italic);
+                        itemText += " (" + sequenceItem.Probability.ToString() + "%)";
+                    }
+
+                    listItem.Text = itemText;
 
                     String sampleString = sequencer.GenerateSequenceItem(wordSequenceItem, config, randomizer);
                     
@@ -409,7 +418,6 @@ namespace Sequencer.Forms
         private void InitializeComponent()
         {
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-            this.substitutionList1 = new Sequencer.Forms.SubstitutionListControl();
             this.label3 = new System.Windows.Forms.Label();
             this.txtCharacterList = new System.Windows.Forms.TextBox();
             this.txtWordList = new System.Windows.Forms.TextBox();
@@ -420,7 +428,6 @@ namespace Sequencer.Forms
             this.label1 = new System.Windows.Forms.Label();
             this.lvSequence = new System.Windows.Forms.ListView();
             this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader3 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.toolStrip1 = new System.Windows.Forms.ToolStrip();
             this.toolStripLabel1 = new System.Windows.Forms.ToolStripLabel();
@@ -440,6 +447,7 @@ namespace Sequencer.Forms
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.tsbUp = new System.Windows.Forms.ToolStripButton();
             this.tsbDown = new System.Windows.Forms.ToolStripButton();
+            this.substitutionList1 = new Sequencer.Forms.SubstitutionListControl();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -472,19 +480,6 @@ namespace Sequencer.Forms
             this.splitContainer1.Size = new System.Drawing.Size(997, 545);
             this.splitContainer1.SplitterDistance = 266;
             this.splitContainer1.TabIndex = 0;
-            // 
-            // substitutionList1
-            // 
-            this.substitutionList1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.substitutionList1.Location = new System.Drawing.Point(13, 163);
-            this.substitutionList1.Name = "substitutionList1";
-            this.substitutionList1.Size = new System.Drawing.Size(973, 100);
-            this.substitutionList1.Substitutions = null;
-            this.substitutionList1.TabIndex = 5;
-            this.substitutionList1.SelectedIndexChanged += new System.EventHandler(this.substitutionList1_SelectedIndexChanged);
-            this.substitutionList1.SubstitutionChanged += new System.EventHandler(this.substitutionList1_SubstitutionChanged);
             // 
             // label3
             // 
@@ -572,7 +567,6 @@ namespace Sequencer.Forms
             // 
             this.lvSequence.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.columnHeader1,
-            this.columnHeader2,
             this.columnHeader3});
             this.lvSequence.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lvSequence.FullRowSelect = true;
@@ -589,13 +583,10 @@ namespace Sequencer.Forms
             // 
             this.columnHeader1.Text = "Type";
             // 
-            // columnHeader2
-            // 
-            this.columnHeader2.Text = "Probability";
-            // 
             // columnHeader3
             // 
             this.columnHeader3.Text = "Sample";
+            this.columnHeader3.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.columnHeader3.Width = 442;
             // 
             // toolStrip1
@@ -755,6 +746,19 @@ namespace Sequencer.Forms
             this.tsbDown.Size = new System.Drawing.Size(23, 22);
             this.tsbDown.Text = "tsbDown";
             this.tsbDown.Click += new System.EventHandler(this.tsbDown_Click);
+            // 
+            // substitutionList1
+            // 
+            this.substitutionList1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.substitutionList1.Location = new System.Drawing.Point(13, 163);
+            this.substitutionList1.Name = "substitutionList1";
+            this.substitutionList1.Size = new System.Drawing.Size(973, 100);
+            this.substitutionList1.Substitutions = null;
+            this.substitutionList1.TabIndex = 5;
+            this.substitutionList1.SelectedIndexChanged += new System.EventHandler(this.substitutionList1_SelectedIndexChanged);
+            this.substitutionList1.SubstitutionChanged += new System.EventHandler(this.substitutionList1_SubstitutionChanged);
             // 
             // MainForm
             // 

--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -106,48 +106,43 @@ namespace Sequencer.Forms
 
                 listItem.Tag = sequenceItem;
 
+                string itemText = "";
+
+                string sampleString = sequencer.GenerateSequenceItem(sequenceItem, config, randomizer);
+
+                for (int i=1; i<5; i+=1)
+                {
+                    sampleString += " " + sequencer.GenerateSequenceItem(sequenceItem, config, randomizer);
+                }
+                listItem.SubItems.Add(string.Format(sampleString));
+                /* TODO: substitutions aren't applying at this point...why? 
+                 * Answer: I think it's because modifying substitution list
+                 * doesn't save the config! Should save config after editing
+                 * those fields, and refresh this list, I guess.
+                 * Need to check if all word lists are applied, too.
+                 */
+
                 if (sequenceItem is CharacterSequenceItem)
                 {
-                    CharacterSequenceItem characterSequenceItem = (CharacterSequenceItem)sequenceItem;
-                    listItem.Text = "Characters (" + sequenceItem.Probability.ToString() + ")";
-                    listItem.SubItems.Add(string.Format("Length: {0} ({1}), Override: {2}",
-                        characterSequenceItem.Length,
-                        characterSequenceItem.LengthStrength.ToString(),
-                        characterSequenceItem.Characters != null ? characterSequenceItem.Characters.Override.ToString().ToLower() : "false"));
-                    listItem.SubItems.Add(characterSequenceItem.Characters != null ? characterSequenceItem.Characters.ToString() : "(Defaults)");
+                    itemText += "Characters";
                 }
                 else if (sequenceItem is WordSequenceItem)
                 {
-                    WordSequenceItem wordSequenceItem = (WordSequenceItem)sequenceItem;
-                    string itemText = "Word";
-
-                    if (sequenceItem.Probability == Sequencer.Configuration.PercentEnum.Never)
-                    {
-                        listItem.Font = new Font(listItem.Font, listItem.Font.Style | FontStyle.Strikeout);
-                    }
-                    else if (sequenceItem.Probability < Sequencer.Configuration.PercentEnum.Always)
-                    {
-                        listItem.Font = new Font(listItem.Font, listItem.Font.Style | FontStyle.Italic);
-                        itemText += " (" + sequenceItem.Probability.ToString() + "%)";
-                    }
-
-                    listItem.Text = itemText;
-
-                    String sampleString = sequencer.GenerateSequenceItem(wordSequenceItem, config, randomizer);
-                    
-                    for (int i=1; i<5; i+=1)
-                    {
-                      sampleString += " " + sequencer.GenerateSequenceItem(wordSequenceItem, config, randomizer);
-                    }
-
-                    /* TODO: substitutions aren't applying at this point...why? 
-                     * Answer: I think it's because modifying substitution list
-                     * doesn't save the config! Should save config after editing
-                     * those fields, and refresh this list, I guess.
-                     * Need to check if all word lists are applied, too.
-                     */
-                    listItem.SubItems.Add(string.Format(sampleString));
+                    itemText += "Word";
                 }
+
+                if (sequenceItem.Probability == Sequencer.Configuration.PercentEnum.Never)
+                {
+                    listItem.Font = new Font(listItem.Font, listItem.Font.Style | FontStyle.Strikeout);
+                    listItem.ForeColor = System.Drawing.Color.Gray;
+                }
+                else if (sequenceItem.Probability < Sequencer.Configuration.PercentEnum.Always)
+                {
+                    listItem.Font = new Font(listItem.Font, listItem.Font.Style | FontStyle.Italic);
+                    itemText += " (" + sequenceItem.Probability.ToString() + "%)";
+                }
+                listItem.Text = itemText;
+
                 if (sequenceItem == lastSelectedItem)
                 {
                     listItem.Selected = true;
@@ -582,6 +577,7 @@ namespace Sequencer.Forms
             // columnHeader1
             // 
             this.columnHeader1.Text = "Type";
+            this.columnHeader1.Width = 111;
             // 
             // columnHeader3
             // 

--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -98,7 +98,6 @@ namespace Sequencer.Forms
                         new CryptoRandomStream(CrsAlgorithm.Salsa20, pbKey));
 
             WordSequence.Sequencer sequencer = new WordSequence.Sequencer();
-            PasswordSequenceConfiguration config = sequencer.Load();
 
             foreach (SequenceItem sequenceItem in Configuration.Sequence)
             {
@@ -108,11 +107,11 @@ namespace Sequencer.Forms
 
                 string itemText = "";
 
-                string sampleString = sequencer.GenerateSequenceItem(sequenceItem, config, randomizer);
+                string sampleString = sequencer.GenerateSequenceItem(sequenceItem, Configuration, randomizer);
 
                 for (int i=1; i<5; i+=1)
                 {
-                    sampleString += " " + sequencer.GenerateSequenceItem(sequenceItem, config, randomizer);
+                    sampleString += " " + sequencer.GenerateSequenceItem(sequenceItem, Configuration, randomizer);
                 }
                 listItem.SubItems.Add(string.Format(sampleString));
                 /* TODO: substitutions aren't applying at this point...why? 

--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -374,7 +374,7 @@ namespace Sequencer.Forms
 
         private void lengthToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            ReadUserInputFor<CharacterSequenceItem, byte>("Length [1-255]", "[1-255]", i => i.Length);
+            ReadUserInputFor<CharacterSequenceItem, uint>("Length [1-255]", "[1-255]", i => i.Length);
         }
 
         private void lengthStrengthToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Forms/MainForm.resx
+++ b/Forms/MainForm.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="label4.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
+  <metadata name="label5.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
   <metadata name="toolStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>122, 17</value>
   </metadata>

--- a/Sequencer.cs
+++ b/Sequencer.cs
@@ -139,7 +139,7 @@ namespace WordSequence
             foreach (SequenceItem sequenceItem in globalConfiguration.Sequence)
             {
                 if (sequenceItem.Probability != PercentEnum.Never &&
-                        (int)cryptoRandom.GetRandomInRange(0, 100) <= (int)sequenceItem.Probability)
+                    (int)cryptoRandom.GetRandomInRange(1, 100) <= (int)sequenceItem.Probability)
                 {
                     targetSequence += GenerateSequenceItem(sequenceItem, globalConfiguration, cryptoRandom);
                 }
@@ -165,11 +165,12 @@ namespace WordSequence
         {
             string targetCharacterSet = string.Empty;
             List<char> characterList = null;
-            int length = characterItem.Length;
-            if (characterItem.LengthStrength != StrengthEnum.Full &&
-                (int)cryptoRandom.GetRandomInRange(0, 100) < (int)characterItem.LengthStrength)
+            uint length = characterItem.Length;
+            if (length > 0 &&
+                characterItem.LengthStrength != StrengthEnum.Full &&
+                (int)cryptoRandom.GetRandomInRange(1, 100) <= (uint)characterItem.LengthStrength)
             {
-              length = (int)cryptoRandom.GetRandomInRange(0, characterItem.Length);
+              length = (uint)cryptoRandom.GetRandomInRange(0, characterItem.Length-1);
             }
 
             while (targetCharacterSet.Length < length)
@@ -220,7 +221,7 @@ namespace WordSequence
                 }
                 foreach (BaseSubstitution substitution in applicableSubstitution)
                 {
-                    if ((int)cryptoRandom.GetRandomInRange(0, 100) <= (int)wordItem.Substitution)
+                    if ((int)cryptoRandom.GetRandomInRange(1, 100) <= (int)wordItem.Substitution)
                     {
                         targetWord = ApplySubstitutionItem(substitution, targetWord);
                     }
@@ -235,7 +236,7 @@ namespace WordSequence
             {
                 string capitalizedWord = string.Empty;
                 foreach (char c in targetWord)
-                    if ((int)cryptoRandom.GetRandomInRange(0, 100) <= (int)wordItem.Capitalize)
+                    if ((int)cryptoRandom.GetRandomInRange(1, 100) <= (int)wordItem.Capitalize)
                         capitalizedWord += c.ToString().ToUpper();
                     else
                         capitalizedWord += c.ToString().ToLower();

--- a/Sequencer.cs
+++ b/Sequencer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Windows.Forms;
 using System.Xml;
 using System.Xml.Serialization;
 using KeePassLib;
@@ -74,6 +75,8 @@ namespace WordSequence
              * config when user config not found
              */
             string configFile = GetConfigurationPath(false);
+            PasswordSequenceConfiguration config;
+
             if (null != configFile && File.Exists(configFile))
             {
                 /* TODO: replace xsd path with local path instead of web path
@@ -85,7 +88,15 @@ namespace WordSequence
                 FileStream configStream = File.OpenRead(configFile);
                 try
                 {
-                    return (PasswordSequenceConfiguration)serializer.Deserialize(XmlReader.Create(configStream));
+                    config = (PasswordSequenceConfiguration)serializer.Deserialize(XmlReader.Create(configStream));
+                }
+                catch (InvalidOperationException)
+                {
+                    MessageBox.Show(
+                            "An error occurred reading the Word Sequencer configuration file at " + configFile + ". It may be corrupt. Fix or delete and try again.",
+                            "Error Reading Configuration", 
+                            MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    config = new PasswordSequenceConfiguration(true);
                 }
                 finally
                 {
@@ -95,9 +106,10 @@ namespace WordSequence
             else
             {
                 /* Config file not found; create empty config */
-                return new PasswordSequenceConfiguration(true);
+                config = new PasswordSequenceConfiguration(true);
                 /* TODO: pop up an error message or something? */
             }
+            return config;
         }
 
         public void Save(PasswordSequenceConfiguration configuration)


### PR DESCRIPTION
I replaced the list of config option values in the UI with a set of sample text the options will generate. I think it is clearer and easier to use that way. The samples will now update with every change to the config settings.

To give a better feel for the whole password, I also added a full-password preview, plus a rudimentary progress bar for entropy/password strength.

The progress bar does not quite fix #7 because it does not yet account for all the detailed options of each item. I have a good idea how to move forward with that, but I'll make that a new pull request.
