### PR TITLE
Fix/configuration load

### DIFF
--- a/CryptoRandomRange.cs
+++ b/CryptoRandomRange.cs
@@ -1,7 +1,7 @@
 using KeePassLib.Cryptography;
 using KeePassLib.Cryptography.PasswordGenerator;
 
-namespace WordSequence
+namespace Sequencer
 {
     /* This class exists to restrict the 64-bit random provided by the KeePass
      * library to a range, without bias. Probably this should be built into

--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -60,7 +60,7 @@ namespace Sequencer.Forms
         {
             base.OnLoad(e);
 
-            Configuration = new WordSequence.Sequencer().Load();
+            Configuration = new Sequencer().Load();
 
             LoadConfigurationDetails();
         }
@@ -68,7 +68,7 @@ namespace Sequencer.Forms
         protected override void OnClosing(CancelEventArgs e)
         {
             base.OnClosing(e);
-            new WordSequence.Sequencer().Save(Configuration);
+            new Sequencer().Save(Configuration);
         }
 
         private void UpdateConfigurationSubstitutions()
@@ -414,7 +414,7 @@ namespace Sequencer.Forms
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.tsbUp = new System.Windows.Forms.ToolStripButton();
             this.tsbDown = new System.Windows.Forms.ToolStripButton();
-            this.substitutionList1 = new Sequencer.Forms.SubstitutionListControl();
+            this.substitutionList1 = new SubstitutionListControl();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();

--- a/Forms/WordSequenceForm.cs
+++ b/Forms/WordSequenceForm.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
 using Sequencer.Configuration;
-using WordSequence;
 
 namespace Sequencer.Forms
 {

--- a/GeneratorPlugin.cs
+++ b/GeneratorPlugin.cs
@@ -5,7 +5,7 @@ namespace Sequencer
     public class SequencerExt : Plugin
     {
         private IPluginHost m_host = null;
-        private WordSequence.Sequencer m_gen = null;
+        private Sequencer m_gen = null;
 
 
         public override bool Initialize(IPluginHost host)
@@ -14,7 +14,7 @@ namespace Sequencer
             if (host == null) return false;
             m_host = host;
 
-            m_gen = new WordSequence.Sequencer();
+            m_gen = new Sequencer();
             m_host.PwGeneratorPool.Add(m_gen);
 
             return true;

--- a/Sequencer.cs
+++ b/Sequencer.cs
@@ -53,8 +53,9 @@ namespace Sequencer
 
             if (null == config || !(getPathForWrite || File.Exists(config)))
             {
-                config = appConfig.AppSettings.Settings["defaultConfigPath"].Value;
-                if (null == config)
+                if (appConfig.AppSettings.Settings["defaultConfigPath"] != null)
+                    config = appConfig.AppSettings.Settings["defaultConfigPath"].Value;
+                if (null == config && appConfig.AppSettings.Settings["configPath"] != null)
                 {
                     config = appConfig.AppSettings.Settings["configPath"].Value;
                 }
@@ -69,10 +70,6 @@ namespace Sequencer
                 return null; /* TODO: better to throw exception? */
             }
         }
-
-        private System.Configuration.Configuration Configuration { get {
-        return _configuration ?? (_configuration = System.Configuration.ConfigurationManager.OpenExeConfiguration(this.GetType().Assembly.Location));
-    }}
 
         public PasswordSequenceConfiguration Load()
         {

--- a/Sequencer.cs
+++ b/Sequencer.cs
@@ -12,7 +12,7 @@ using KeePassLib.Security;
 using Sequencer.Configuration;
 using Sequencer.Forms;
 
-namespace WordSequence
+namespace Sequencer
 {
     public class Sequencer : CustomPwGenerator
     {
@@ -37,25 +37,27 @@ namespace WordSequence
              *  http://stackoverflow.com/a/2272628/1390430
              */
             var appConfig = System.Configuration.ConfigurationManager.OpenExeConfiguration(this.GetType().Assembly.Location);
-            string config = appConfig.AppSettings.Settings["userConfigPath"].Value;
+            string config = null;
+            if (appConfig.AppSettings.Settings["userConfigPath"] != null)
+                config = appConfig.AppSettings.Settings["userConfigPath"].Value;
 
             if (null != config)
             {
-              if (!System.IO.Path.IsPathRooted(config))
-              {
-                config = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                    config);
-              }
+                if (!System.IO.Path.IsPathRooted(config))
+                {
+                    config = Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                        config);
+                }
             }
 
             if (null == config || !(getPathForWrite || File.Exists(config)))
             {
-              config = appConfig.AppSettings.Settings["defaultConfigPath"].Value;
-              if (null == config)
-              {
-                config = appConfig.AppSettings.Settings["configPath"].Value;
-              }
+                config = appConfig.AppSettings.Settings["defaultConfigPath"].Value;
+                if (null == config)
+                {
+                    config = appConfig.AppSettings.Settings["configPath"].Value;
+                }
             }
 
             if (null != config && (getPathForWrite || File.Exists(config)))
@@ -67,6 +69,10 @@ namespace WordSequence
                 return null; /* TODO: better to throw exception? */
             }
         }
+
+        private System.Configuration.Configuration Configuration { get {
+        return _configuration ?? (_configuration = System.Configuration.ConfigurationManager.OpenExeConfiguration(this.GetType().Assembly.Location));
+    }}
 
         public PasswordSequenceConfiguration Load()
         {
@@ -148,9 +154,9 @@ namespace WordSequence
             return targetSequence;
         }
 
-        public string GenerateSequenceItem(SequenceItem                  sequenceItem,
+        public string GenerateSequenceItem(SequenceItem sequenceItem,
                                            PasswordSequenceConfiguration globalConfiguration,
-                                           CryptoRandomRange             cryptoRandom)
+                                           CryptoRandomRange cryptoRandom)
         {
             if (sequenceItem is CharacterSequenceItem)
                 return GenerateSequenceItem((CharacterSequenceItem)sequenceItem, globalConfiguration, cryptoRandom);
@@ -159,9 +165,9 @@ namespace WordSequence
             return null;
         }
 
-        public string GenerateSequenceItem(CharacterSequenceItem         characterItem,
+        public string GenerateSequenceItem(CharacterSequenceItem characterItem,
                                            PasswordSequenceConfiguration globalConfiguration,
-                                           CryptoRandomRange             cryptoRandom)
+                                           CryptoRandomRange cryptoRandom)
         {
             string targetCharacterSet = string.Empty;
             List<char> characterList = null;
@@ -169,7 +175,7 @@ namespace WordSequence
             if (characterItem.LengthStrength != StrengthEnum.Full &&
                 (int)cryptoRandom.GetRandomInRange(0, 100) < (int)characterItem.LengthStrength)
             {
-              length = (int)cryptoRandom.GetRandomInRange(0, characterItem.Length);
+                length = (int)cryptoRandom.GetRandomInRange(0, characterItem.Length);
             }
 
             while (targetCharacterSet.Length < length)
@@ -183,7 +189,7 @@ namespace WordSequence
                         characterList.AddRange(globalConfiguration.DefaultCharacters);
                 }
 
-                int charPos = (int)cryptoRandom.GetRandomInRange(0, (ulong)characterList.Count-1);
+                int charPos = (int)cryptoRandom.GetRandomInRange(0, (ulong)characterList.Count - 1);
                 targetCharacterSet += characterList[charPos];
                 if (!characterItem.AllowDuplicate)
                     characterList.RemoveAt(charPos);
@@ -192,9 +198,9 @@ namespace WordSequence
             return targetCharacterSet;
         }
 
-        public string GenerateSequenceItem(WordSequenceItem              wordItem,
+        public string GenerateSequenceItem(WordSequenceItem wordItem,
                                            PasswordSequenceConfiguration globalConfiguration,
-                                           CryptoRandomRange             cryptoRandom)
+                                           CryptoRandomRange cryptoRandom)
         {
             string targetWord;
             {
@@ -204,7 +210,7 @@ namespace WordSequence
                 if (wordItem.Words == null || !wordItem.Words.Override)
                     wordList.AddRange(globalConfiguration.DefaultWords);
 
-                targetWord = wordList[(int)cryptoRandom.GetRandomInRange(0, (ulong)wordList.Count-1)];
+                targetWord = wordList[(int)cryptoRandom.GetRandomInRange(0, (ulong)wordList.Count - 1)];
             }
 
             if (wordItem.Substitution > PercentEnum.Never)


### PR DESCRIPTION
Fixes #19, if no configuration is defined, GetConfigurationPath will return null.
Also renamed namespace, to remove WordSequence, should now all be Sequencer.
