### PR TITLE
Make substitution code match entropy calculation

### DIFF
--- a/Configuration/Model/WordSequenceItem.cs
+++ b/Configuration/Model/WordSequenceItem.cs
@@ -52,7 +52,7 @@ namespace Sequencer.Configuration.Model
                 avg_word_len += word.Length;
                 foreach (BaseSubstitution substitution in applicableSubstitution)
                 {
-                    subst_hit_count += new SubstitutionVisitor()
+                    subst_hit_count += new SubstitutionVisitor(null)
                                             .CountSubstitution(substitution, word);
                 }
             }

--- a/ItemVisitor/AnySubstitutionVisitor.cs
+++ b/ItemVisitor/AnySubstitutionVisitor.cs
@@ -6,15 +6,20 @@ namespace Sequencer.ItemVisitor
 {
     class AnySubstitutionVisitor : ISubstitutionVisitor<AnySubstitution>
     {
-        public string ApplySubstitutionItem(AnySubstitution substitution, string word)
+        public AnySubstitutionVisitor(CryptoRandomRange cryptoRandom) 
         {
-            return ForEachSubstitution(substitution, word, (f, r) => f + r);
+            myCryptoRandom = cryptoRandom;
+        }
+
+        public string ApplySubstitutionItem(AnySubstitution substitution, string word, ulong substChance)
+        {
+            return ForEachSubstitution(substitution, word, substChance, (f, r) => f + r);
         }
 
         public int CountSubstitution(AnySubstitution substitution, string word)
         {
             int count = 0;
-            ForEachSubstitution(substitution, word, (f, r) =>
+            ForEachSubstitution(substitution, word, 100, (f, r) =>
             {
                 count++;
                 return f;
@@ -22,7 +27,10 @@ namespace Sequencer.ItemVisitor
             return count;
         }
 
-        private string ForEachSubstitution(AnySubstitution substitution, string word, Func<string, string, string> operation)
+        private string ForEachSubstitution(AnySubstitution substitution,
+                                           string word,
+                                           ulong substChance,
+                                           Func<string, string, string> operation)
         {
             string substitutedWord = string.Empty;
             string replacePattern = substitution.Replace;
@@ -34,7 +42,8 @@ namespace Sequencer.ItemVisitor
 
             for (int i = 0; i < word.Length; i++)
             {
-                if (replacePattern.Contains(cursorWord[i].ToString(CultureInfo.InvariantCulture)))
+                if (replacePattern.Contains(cursorWord[i].ToString(CultureInfo.InvariantCulture)) &&
+                        (substChance >= 100 || myCryptoRandom.GetRandomInRange(1, 100) <= substChance) )
                 {
                     substitutedWord = operation(substitutedWord, substitution.With);
                 }
@@ -44,7 +53,8 @@ namespace Sequencer.ItemVisitor
                 }
             }
             return substitutedWord;
-
         }
+
+        private CryptoRandomRange myCryptoRandom;
     }
 }

--- a/ItemVisitor/ISubstitutionVisitor.cs
+++ b/ItemVisitor/ISubstitutionVisitor.cs
@@ -4,7 +4,7 @@ namespace Sequencer.ItemVisitor
 {
     interface ISubstitutionVisitor<TSubstitution> where TSubstitution : BaseSubstitution
     {
-        string ApplySubstitutionItem(TSubstitution substitution, string word);
+        string ApplySubstitutionItem(TSubstitution substitution, string word, ulong substChance);
         int CountSubstitution(TSubstitution substitution, string word);
     }
 }

--- a/ItemVisitor/SubstitutionVisitor.cs
+++ b/ItemVisitor/SubstitutionVisitor.cs
@@ -8,18 +8,22 @@ namespace Sequencer.ItemVisitor
 {
     class SubstitutionVisitor : ISubstitutionVisitor<BaseSubstitution>
     {
+        public SubstitutionVisitor(CryptoRandomRange cryptoRandom) 
+        {
+            myCryptoRandom = cryptoRandom;
+        }
 
-        public string ApplySubstitutionItem(BaseSubstitution substitution, string word)
+        public string ApplySubstitutionItem(BaseSubstitution substitution, string word, ulong substChance)
         {
             var anySubstitution = substitution as AnySubstitution;
             if (anySubstitution != null)
             {
-                return new AnySubstitutionVisitor().ApplySubstitutionItem(anySubstitution, word);
+                return new AnySubstitutionVisitor(myCryptoRandom).ApplySubstitutionItem(anySubstitution, word, substChance);
             }
             var wholeSubstitution = substitution as WholeSubstitution;
             if (wholeSubstitution != null)
             {
-                return new WholeSubstitutionVisitor().ApplySubstitutionItem(wholeSubstitution, word);
+                return new WholeSubstitutionVisitor(myCryptoRandom).ApplySubstitutionItem(wholeSubstitution, word, substChance);
             }
             return word;
         }
@@ -29,14 +33,16 @@ namespace Sequencer.ItemVisitor
             var anySubstitution = substitution as AnySubstitution;
             if (anySubstitution != null)
             {
-                return new AnySubstitutionVisitor().CountSubstitution(anySubstitution, word);
+                return new AnySubstitutionVisitor(myCryptoRandom).CountSubstitution(anySubstitution, word);
             }
             var wholeSubstitution = substitution as WholeSubstitution;
             if (wholeSubstitution != null)
             {
-                return new WholeSubstitutionVisitor().CountSubstitution(wholeSubstitution, word);
+                return new WholeSubstitutionVisitor(myCryptoRandom).CountSubstitution(wholeSubstitution, word);
             }
             return 0;
         }
+
+        private CryptoRandomRange myCryptoRandom;
     }
 }

--- a/ItemVisitor/SubstitutionsVisitor.cs
+++ b/ItemVisitor/SubstitutionsVisitor.cs
@@ -21,8 +21,7 @@ namespace Sequencer.ItemVisitor
                 if (item.Substitutions == null || !item.Substitutions.Override)
                     applicableSubstitution.AddRange(_globalConfiguration.DefaultSubstitutions);
                 foreach (BaseSubstitution substitution in applicableSubstitution)
-                    if (cryptoRandom.GetRandomInRange(1, 100) <= (ulong)item.Substitution)
-                        word = new SubstitutionVisitor().ApplySubstitutionItem(substitution, word);
+                    word = new SubstitutionVisitor(cryptoRandom).ApplySubstitutionItem(substitution, word, (ulong)item.Substitution);
             }
             return word;
         }

--- a/ItemVisitor/WholeSubstitutionVisitor.cs
+++ b/ItemVisitor/WholeSubstitutionVisitor.cs
@@ -4,15 +4,20 @@ namespace Sequencer.ItemVisitor
 {
     class WholeSubstitutionVisitor : ISubstitutionVisitor<WholeSubstitution>
     {
-        public string ApplySubstitutionItem(WholeSubstitution substitution, string word)
+        public WholeSubstitutionVisitor(CryptoRandomRange cryptoRandom) 
         {
-            return ForEachSubstitution(substitution, word, (f, r) => f + r);
+            myCryptoRandom = cryptoRandom;
+        }
+
+        public string ApplySubstitutionItem(WholeSubstitution substitution, string word, ulong substChance)
+        {
+            return ForEachSubstitution(substitution, word, substChance, (f, r) => f + r);
         }
 
         public int CountSubstitution(WholeSubstitution substitution, string word)
         {
             int count = 0;
-            ForEachSubstitution(substitution, word, (f, r) =>
+            ForEachSubstitution(substitution, word, 100, (f, r) =>
             {
                 count++;
                 return f;
@@ -20,7 +25,10 @@ namespace Sequencer.ItemVisitor
             return count;
         }
 
-        private string ForEachSubstitution(WholeSubstitution substitution, string word, Func<string, string, string> operation)
+        private string ForEachSubstitution(WholeSubstitution substitution,
+                                           string word,
+                                           ulong substChance,
+                                           Func<string, string, string> operation)
         {
             string substitutedWord = string.Empty;
             string replacePattern = substitution.Replace;
@@ -32,7 +40,8 @@ namespace Sequencer.ItemVisitor
 
             for (int i = 0; i < word.Length; i++)
             {
-                if (cursorWord.Substring(i).StartsWith(replacePattern))
+                if (cursorWord.Substring(i).StartsWith(replacePattern) &&
+                        (substChance >= 100 || myCryptoRandom.GetRandomInRange(1, 100) <= substChance) )
                 {
                     substitutedWord = operation(substitutedWord, substitution.With);
                     i += replacePattern.Length - 1;
@@ -45,5 +54,6 @@ namespace Sequencer.ItemVisitor
             return substitutedWord;
         }
 
+        private CryptoRandomRange myCryptoRandom;
     }
 }


### PR DESCRIPTION
Now each matched position is evaluated for a random substitution,
instead of each word evaluated randomly to have substitution applied throughout.

Fixes #35 
