### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Have a look at the [wiki for the user documentation](https://github.com/fireout/
 
 ## Releases
 
-Releases are located in the [release folder](https://github.com/fireout/keepasssequencer/tree/master/release).  You can copy the Sequencer.dll and Sequencer.dll.config in the KeePass directory.  See the [wiki](https://github.com/fireout/keepasssequencer/wiki/1.-Installation) for more details.
+Releases are located in the github [release section](https://github.com/fireout/keepasssequencer/releases) and in the [release folder](https://github.com/fireout/keepasssequencer/tree/master/release).  
+You can copy the Sequencer.dll and Sequencer.dll.config in the KeePass directory.  See the [wiki](https://github.com/fireout/keepasssequencer/wiki/1.-Installation) for more details.
 
 ## Source Code
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@
 
 Have a look at the [wiki for the user documentation](https://github.com/fireout/keepasssequencer/wiki)
 
-You can run from the bin/Release folder, if you stick a copy of KeePass.exe.config there.
+## Releases
 
-Generated passwords will be empty until you configure some settings. You can do this from within the app, or by copying the options.xml or 
-SamplePasswordSequenceConfiguration.xml from the project root directory into one of the paths specified in the Sequencer.dll.config file.
+Releases are located in the [release folder](https://github.com/fireout/keepasssequencer/tree/master/release).  You can copy the Sequencer.dll and Sequencer.dll.config in the KeePass directory.  See the [wiki](https://github.com/fireout/keepasssequencer/wiki/1.-Installation) for more details.
 
 ## Source Code
 

--- a/release/readme.MD
+++ b/release/readme.MD
@@ -4,4 +4,6 @@
 For instruction, see the [wiki](https://github.com/fireout/keepasssequencer/wiki/1.-Installation)
 
 ## Current release
-Current release is 0.0.2 which is an alpha release.
+Current release is 0.1.1.  
+You can download it from the [releases section](https://github.com/fireout/keepasssequencer/releases) or from the [release 
+folder](https://github.com/fireout/keepasssequencer/tree/master/release)


### PR DESCRIPTION
Modified the readme to reflect most recent release/changes

I removed :

```
-Generated passwords will be empty until you configure some settings. You can do this from within the app, or by copying the options.xml or 
-SamplePasswordSequenceConfiguration.xml from the project root directory into one of the paths specified in the Sequencer.dll.config file.
```

I think a link to the wiki is enough (?).
